### PR TITLE
IPv6 compatibility

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -17,7 +17,7 @@ import (
 )
 
 func getExternalIP() (string, error) {
-	resp, err := http.Get("https://icanhazip.com")
+	resp, err := http.Get("https://ipv4.icanhazip.com")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://icanhazip.com returns ipv6 if external ipv6 is available. Use https://ipv4.icanhazip.com instead to get ipv4